### PR TITLE
ハッシュセットによる重複判定の高速化

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ classDiagram
     class UISpriteOverlapDetector {
         + List notUIs
         + List UIs
-        - List previousState
+        - HashSet previousState
         - IOverlapStrategy strategy
 
         + event OnOverlapEnter


### PR DESCRIPTION
## 概要
- previousState と currentState を HashSet に変更
- 集合演算を用いて重複チェックと削除を高速化

## テスト
- `dotnet build UISpriteOverlapDetector.sln` : `command not found: dotnet`
- `apt-get update` : リポジトリ署名エラーのため実行不可

------
https://chatgpt.com/codex/tasks/task_e_689b7ee71284832a9d22600760dbadba