### PR TITLE
includeRotatedをプロパティ化してstrategy再生成を自動化

### DIFF
--- a/UISpriteOverlapDetector/source/UISpriteOverlapDetector.cs
+++ b/UISpriteOverlapDetector/source/UISpriteOverlapDetector.cs
@@ -19,6 +19,7 @@ public sealed class UISpriteOverlapDetector : MonoBehaviour
     [Header("オプション")]
     [SerializeField] private bool visualizeGizmos = true;
     [SerializeField] private bool includeRotated  = false;
+    private bool includeRotatedState;
 
     public event Action<Component, RectTransform> OnOverlapEnter;
     public event Action<Component, RectTransform> OnOverlapStay;
@@ -84,12 +85,32 @@ public sealed class UISpriteOverlapDetector : MonoBehaviour
             targetCanvas = GetComponentInParent<Canvas>();
         }
 
+        includeRotatedState = includeRotated;
         strategy     = includeRotated ? new SATStrategy() : new AABBStrategy();
         currentState = new HashSet<PairKey>();
         entered      = new HashSet<PairKey>();
         stayed       = new HashSet<PairKey>();
         exited       = new HashSet<PairKey>();
     }
+
+    public bool IncludeRotated
+    {
+        get => includeRotated;
+        set
+        {
+            if (includeRotatedState == value) return;
+            includeRotated = value;
+            includeRotatedState = value;
+            strategy = includeRotated ? new SATStrategy() : new AABBStrategy();
+        }
+    }
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        IncludeRotated = includeRotated;
+    }
+#endif
 
     private void LateUpdate()
     {


### PR DESCRIPTION
## 概要
- includeRotatedをSerializeFieldのバッキングフィールド＋プロパティに変更
- プロパティ変更時にstrategyを再生成するよう対応
- OnValidateでもプロパティ経由で設定しエディタ上の変更を反映

## テスト
- `dotnet build UISpriteOverlapDetector.sln` (dotnet未インストールのため失敗)


------
https://chatgpt.com/codex/tasks/task_e_689da365a340832a82d2621a6edaa231