### PR TITLE
IncludeRotated プロパティの再生成条件を簡素化

### DIFF
--- a/UISpriteOverlapDetector/source/UISpriteOverlapDetector.cs
+++ b/UISpriteOverlapDetector/source/UISpriteOverlapDetector.cs
@@ -19,15 +19,13 @@ public sealed class UISpriteOverlapDetector : MonoBehaviour
     [Header("オプション")]
     [SerializeField] private bool visualizeGizmos = true;
     [SerializeField] private bool includeRotated  = false;
-    private bool includeRotatedState;
     public bool IncludeRotated
     {
         get => includeRotated;
         set
         {
-            if (includeRotatedState == value) return;
-            includeRotated      = value;
-            includeRotatedState = value;
+            if (includeRotated == value) return;
+            includeRotated = value;
             strategy = includeRotated ? new SATStrategy() : new AABBStrategy();
         }
     }
@@ -95,8 +93,7 @@ public sealed class UISpriteOverlapDetector : MonoBehaviour
             targetCanvas = GetComponentInParent<Canvas>();
         }
 
-        includeRotatedState = includeRotated;
-        strategy     = includeRotated ? new SATStrategy() : new AABBStrategy();
+        strategy = includeRotated ? new SATStrategy() : new AABBStrategy();
         currentState = new HashSet<PairKey>();
         entered      = new HashSet<PairKey>();
         stayed       = new HashSet<PairKey>();
@@ -106,7 +103,7 @@ public sealed class UISpriteOverlapDetector : MonoBehaviour
 #if UNITY_EDITOR
     private void OnValidate()
     {
-        IncludeRotated = includeRotated;
+        strategy = includeRotated ? new SATStrategy() : new AABBStrategy();
     }
 #endif
 


### PR DESCRIPTION
## 概要
- `includeRotatedState` フィールドを削除
- `IncludeRotated` プロパティで同値比較後に `strategy` を再生成
- `Awake` と `OnValidate` から旧フィールド参照を除去

## テスト
- `dotnet build UISpriteOverlapDetector.sln`（`dotnet` 不在のため失敗）
- `apt-get update`（リポジトリ署名エラーにより失敗）

------
https://chatgpt.com/codex/tasks/task_e_689da7c10a08832a8e930845990b1227