### PR TITLE
2D専用化のための型チェックとレジストリ調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # UISpriteOverlapDetector
 
-- Unity2D 用のスクリプト群で、`RectTransform` を持つ UI と `Renderer` や `Collider2D` などの非 UI の重なりを検出する
+- Unity2D 用のスクリプト群で、`RectTransform` を持つ UI と `SpriteRenderer` や `Collider2D` などの非 UI の重なりを検出する
+- 現在は 2D コンポーネントのみをサポートし、3D 対応は今後の予定
 - 対象同士が重なった瞬間、重なっている間、離れた瞬間をそれぞれイベントとして受け取り、UI の半透明化や当たり判定の補助などに利用できる
 
 ## 機能
-- 任意の `RectTransform` と `Renderer` や `Collider2D` を登録して画面上での重なりを監視
+- 任意の `RectTransform` と `SpriteRenderer` または `Collider2D` を登録して画面上での重なりを監視
+- 対応外コンポーネントを登録しようとすると警告ログを出力
 - 重なりの状態に応じて `OnOverlapEnter`、`OnOverlapStay`、`OnOverlapExit` を発火
 - 判定アルゴリズムを `IOverlapStrategy` で差し替え可能
   - 軸整列矩形を用いる `AABBStrategy`
   - 傾きを考慮する `SATStrategy`
 - 非 UI コンポーネントの矩形化は `IQuadProvider` で拡張可能
-  - 標準で `SpriteRenderer`、`Renderer`、`Collider2D` 用を内蔵
+  - 標準で `SpriteRenderer`、`Collider2D` 用を内蔵
 - `IncludeRotated` オプションで自動的に判定方法を切り替え
 - Gizmos による確認用のデバッグ描画
 
@@ -37,11 +39,9 @@ classDiagram
     }
 
     class SpriteRendererQuadProvider
-    class RendererQuadProvider
     class Collider2DQuadProvider
 
     IQuadProvider <|.. SpriteRendererQuadProvider
-    IQuadProvider <|.. RendererQuadProvider
     IQuadProvider <|.. Collider2DQuadProvider
 
     class QuadProviderRegistry {

--- a/UISpriteOverlapDetector/source/QuadProviderRegistry.cs
+++ b/UISpriteOverlapDetector/source/QuadProviderRegistry.cs
@@ -12,7 +12,6 @@ public static class QuadProviderRegistry
     {
         //優先度の高い順に登録されるようソートする
         Register(new SpriteRendererQuadProvider());
-        Register(new RendererQuadProvider());
         Register(new Collider2DQuadProvider());
     }
 

--- a/UISpriteOverlapDetector/source/UISpriteOverlapDetector.cs
+++ b/UISpriteOverlapDetector/source/UISpriteOverlapDetector.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
-/// UI(RectTransform)と非UI(Renderer/Collider2D等)のスクリーン上での重なりを検出するクラス
+/// UI(RectTransform)と非UI(SpriteRenderer/Collider2D)のスクリーン上での重なりを検出するクラス
 /// </summary>
 [DisallowMultipleComponent]
 public sealed class UISpriteOverlapDetector : MonoBehaviour
@@ -67,6 +67,11 @@ public sealed class UISpriteOverlapDetector : MonoBehaviour
             Debug.LogWarning("RectTransformは非UIリストに追加できません", this);
             return;
         }
+        if (comp is not SpriteRenderer && comp is not Collider2D)
+        {
+            Debug.LogWarning($"{comp.GetType().Name}は非UIリストに追加できません", this);
+            return;
+        }
         if (notUIs.Contains(comp)) return;
 
         notUIs.Add(comp);
@@ -97,9 +102,9 @@ public sealed class UISpriteOverlapDetector : MonoBehaviour
         }
         for (int i = notUIs.Count - 1; i >= 0; i--)
         {
-            if (notUIs[i] is RectTransform)
+            if (notUIs[i] is not SpriteRenderer && notUIs[i] is not Collider2D)
             {
-                Debug.LogWarning($"非UIリストにRectTransformが含まれています: {notUIs[i].name}", this);
+                Debug.LogWarning($"非UIリストに対応外コンポーネントが含まれています: {notUIs[i].name}", this);
                 notUIs.RemoveAt(i);
             }
         }


### PR DESCRIPTION
## 概要
- 非UI登録を SpriteRenderer / Collider2D に限定
- QuadProviderRegistry から Renderer 対応を除去
- README を 2D 専用仕様として更新

## テスト
- `dotnet build` (dotnet が見つからないため失敗)
- `apt-get update` (403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_689db1cb030c832a9fbaf58cb5a10473