### PR TITLE
LineRenderer の測定範囲ズレを修正

### DIFF
--- a/UISpriteOverlapDetector/source/QuadProviderRegistry.cs
+++ b/UISpriteOverlapDetector/source/QuadProviderRegistry.cs
@@ -12,6 +12,7 @@ public static class QuadProviderRegistry
     {
         //優先度の高い順に登録されるようソートする
         Register(new SpriteRendererQuadProvider());
+        Register(new RendererQuadProvider());
         Register(new Collider2DQuadProvider());
     }
 

--- a/UISpriteOverlapDetector/source/RendererQuadProvider.cs
+++ b/UISpriteOverlapDetector/source/RendererQuadProvider.cs
@@ -15,11 +15,13 @@ public sealed class RendererQuadProvider : IQuadProvider
 
         var bounds = r.localBounds;
         var ext    = bounds.extents;
+        var center = bounds.center;
 
-        localCorners[0] = new(-ext.x, -ext.y, 0);
-        localCorners[1] = new( ext.x, -ext.y, 0);
-        localCorners[2] = new( ext.x,  ext.y, 0);
-        localCorners[3] = new(-ext.x,  ext.y, 0);
+        // localBoundsの中心が原点からずれている場合に対応する
+        localCorners[0] = new(center.x - ext.x, center.y - ext.y, center.z);
+        localCorners[1] = new(center.x + ext.x, center.y - ext.y, center.z);
+        localCorners[2] = new(center.x + ext.x, center.y + ext.y, center.z);
+        localCorners[3] = new(center.x - ext.x, center.y + ext.y, center.z);
 
         var tf = r.transform;
         for (int i = 0; i < 4; i++)


### PR DESCRIPTION
## 概要
- RendererQuadProvider で localBounds の中心補正を追加
- QuadProviderRegistry に RendererQuadProvider を登録

## テスト
- `dotnet build UISpriteOverlapDetector.sln` : コマンド未導入のため失敗
- `apt-get update` : 403 Forbidden のため失敗

------
https://chatgpt.com/codex/tasks/task_e_689de8fa6970832a99492ef84e6aaf06