### PR TITLE
LineRenderer の重なり判定範囲を適正化

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # UIOverlapDetector
 
-- Unity2D 用のスクリプト群で、`RectTransform` を持つ UI と `SpriteRenderer` や `Collider2D` などの非 UI の重なりを検出する
+- Unity2D 用のスクリプト群で、`RectTransform` を持つ UI と `SpriteRenderer` や `LineRenderer`、`Collider2D` などの非 UI の重なりを検出する
 - 現在は 2D コンポーネントのみをサポートし、3D 対応は今後の予定
 - 対象同士が重なった瞬間、重なっている間、離れた瞬間をそれぞれイベントとして受け取り、UI の半透明化や当たり判定の補助などに利用できる
 
@@ -14,14 +14,14 @@
 - Enter, Exit イベントで UI の透明度を操作している
 
 ## 機能
-- 任意の `RectTransform` と `SpriteRenderer` または `Collider2D` を登録して画面上での重なりを監視
+- 任意の `RectTransform` と `SpriteRenderer`、`LineRenderer`、`Collider2D` を登録して画面上での重なりを監視
 - 対応外コンポーネントを登録しようとすると警告ログを出力
 - 重なりの状態に応じて `OnOverlapEnter`、`OnOverlapStay`、`OnOverlapExit` を発火
 - 判定アルゴリズムを `IOverlapStrategy` で差し替え可能
   - 軸整列矩形を用いる `AABBStrategy`
   - 傾きを考慮する `SATStrategy`
 - 非 UI コンポーネントの矩形化は `IQuadProvider` で拡張可能
-  - 標準で `SpriteRenderer`、`Collider2D` 用を内蔵
+  - 標準で `SpriteRenderer`、`LineRenderer`、`Collider2D` 用を内蔵
 - `IncludeRotated` オプションで自動的に判定方法を切り替え
 - Gizmos による確認用のデバッグ描画
 
@@ -48,9 +48,11 @@ classDiagram
     }
 
     class SpriteRendererQuadProvider
+    class LineRendererQuadProvider
     class Collider2DQuadProvider
 
     IQuadProvider <|.. SpriteRendererQuadProvider
+    IQuadProvider <|.. LineRendererQuadProvider
     IQuadProvider <|.. Collider2DQuadProvider
 
     class QuadProviderRegistry {

--- a/UISpriteOverlapDetector/source/LineRendererQuadProvider.cs
+++ b/UISpriteOverlapDetector/source/LineRendererQuadProvider.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+/// <summary>
+/// LineRenderer専用のQuadProvider
+/// </summary>
+public sealed class LineRendererQuadProvider : IQuadProvider
+{
+    public int Priority => 150;
+
+    public bool TryGetWorldQuad(Component c, Vector3[] worldCorners)
+    {
+        if (c is not LineRenderer lr) return false;
+        if (lr.positionCount < 2) return false;
+
+        Vector3 start = lr.GetPosition(0);
+        Vector3 end   = lr.GetPosition(lr.positionCount - 1);
+
+        if (lr.useWorldSpace == false)
+        {
+            var tf = lr.transform;
+            start = tf.TransformPoint(start);
+            end   = tf.TransformPoint(end);
+        }
+
+        float width = Mathf.Max(lr.startWidth, lr.endWidth) * lr.widthMultiplier;
+        Vector3 dir = (end - start).normalized;
+        if (dir == Vector3.zero) return false;
+        Vector3 normal = Vector3.Cross(dir, Vector3.forward).normalized * (width * 0.5f);
+
+        worldCorners[0] = start + normal;
+        worldCorners[1] = start - normal;
+        worldCorners[2] = end   - normal;
+        worldCorners[3] = end   + normal;
+        return true;
+    }
+}

--- a/UISpriteOverlapDetector/source/QuadProviderRegistry.cs
+++ b/UISpriteOverlapDetector/source/QuadProviderRegistry.cs
@@ -12,6 +12,7 @@ public static class QuadProviderRegistry
     {
         //優先度の高い順に登録されるようソートする
         Register(new SpriteRendererQuadProvider());
+        Register(new LineRendererQuadProvider());
         Register(new RendererQuadProvider());
         Register(new Collider2DQuadProvider());
     }


### PR DESCRIPTION
## Summary
- LineRenderer 用 QuadProvider を追加し線幅に合わせた重なり判定を実現
- QuadProviderRegistry に LineRenderer を登録
- README を LineRenderer 対応の記述に更新

## Testing
- `dotnet build UISpriteOverlapDetector.sln` (command not found)
- `apt-get update` (403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689dea5fe634832ab2442666158a984d