### PR TITLE
IOverlapStrategy をリスト対応にして多角形サイズの制約を撤廃

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ classDiagram
     
     class IOverlapStrategy {
         <<interface>>
-        + bool Overlap(Vector2[] a, Vector2[] b)
+        + bool Overlap(IReadOnlyList<Vector2> a, IReadOnlyList<Vector2> b)
     }
 
     class AABBStrategy

--- a/UISpriteOverlapDetector/source/AABBStrategy.cs
+++ b/UISpriteOverlapDetector/source/AABBStrategy.cs
@@ -1,15 +1,16 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 public sealed class AABBStrategy : IOverlapStrategy
 {
-    public bool Overlap(Vector2[] a, Vector2[] b)
+    public bool Overlap(IReadOnlyList<Vector2> a, IReadOnlyList<Vector2> b)
     {
         Rect ra = CalcBoundingRect(a);
         Rect rb = CalcBoundingRect(b);
         return ra.Overlaps(rb);
     }
 
-    private static Rect CalcBoundingRect(Vector2[] points)
+    private static Rect CalcBoundingRect(IReadOnlyList<Vector2> points)
     {
         float minX = points[0].x, minY = points[0].y;
         float maxX = points[0].x, maxY = points[0].y;

--- a/UISpriteOverlapDetector/source/IOverlapStrategy.cs
+++ b/UISpriteOverlapDetector/source/IOverlapStrategy.cs
@@ -1,7 +1,8 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 public interface IOverlapStrategy
 {
-    // OBB や Rect 型ではなく、四隅の Vector2 配列を受け取る
-    bool Overlap(Vector2[] a, Vector2[] b);
+    // OBB や Rect 型ではなく、任意数の頂点リストを受け取る
+    bool Overlap(IReadOnlyList<Vector2> a, IReadOnlyList<Vector2> b);
 }

--- a/UISpriteOverlapDetector/source/SATStrategy.cs
+++ b/UISpriteOverlapDetector/source/SATStrategy.cs
@@ -1,24 +1,24 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 public sealed class SATStrategy : IOverlapStrategy
 {
-    public bool Overlap(Vector2[] a, Vector2[] b)
+    public bool Overlap(IReadOnlyList<Vector2> a, IReadOnlyList<Vector2> b)
     {
         // 分離軸定理による重なり判定
-        for (int i = 0; i < 4; ++i)
+        for (int i = 0; i < a.Count; ++i)
         {
-            // 各辺の方向ベクトルを正規化して分離軸を取得
-            Vector2 axis;
-            if (i < 2)
+            Vector2 edge = a[(i + 1) % a.Count] - a[i];
+            Vector2 axis = new(-edge.y, edge.x).normalized;
+            if (IsOverlapOnAxis(a, b, axis) == false)
             {
-                axis = (a[(i + 1) % 4] - a[i]).normalized;
+                return false;
             }
-            else
-            {
-                axis = (b[(i - 2 + 1) % 4] - b[i - 2]).normalized;
-            }
-
-            // 1 本でも投影が重ならない軸があれば分離している
+        }
+        for (int i = 0; i < b.Count; ++i)
+        {
+            Vector2 edge = b[(i + 1) % b.Count] - b[i];
+            Vector2 axis = new(-edge.y, edge.x).normalized;
             if (IsOverlapOnAxis(a, b, axis) == false)
             {
                 return false;
@@ -27,18 +27,18 @@ public sealed class SATStrategy : IOverlapStrategy
         return true;
     }
 
-    private static bool IsOverlapOnAxis(Vector2[] A, Vector2[] B, Vector2 axis)
+    private static bool IsOverlapOnAxis(IReadOnlyList<Vector2> A, IReadOnlyList<Vector2> B, Vector2 axis)
     {
         Project(A, axis, out float minA, out float maxA);
         Project(B, axis, out float minB, out float maxB);
         return maxA >= minB && maxB >= minA;
     }
 
-    private static void Project(Vector2[] pts, Vector2 axis, out float min, out float max)
+    private static void Project(IReadOnlyList<Vector2> pts, Vector2 axis, out float min, out float max)
     {
         min = Vector2.Dot(pts[0], axis);
         max = Vector2.Dot(pts[0], axis);
-        for (int i = 1; i < pts.Length; ++i)
+        for (int i = 1; i < pts.Count; ++i)
         {
             float d = Vector2.Dot(pts[i], axis);
             if (d < min)      min = d;


### PR DESCRIPTION
## 概要
- IOverlapStrategy の引数を IReadOnlyList<Vector2> に変更
- AABBStrategy/SATStrategy をリスト対応へ拡張
- UISpriteOverlapDetector の四角配列を List 化し利用箇所を更新
- README のインターフェース記述を修正

## テスト
- `dotnet build UISpriteOverlapDetector.sln` : コマンド未存在
- `apt-get update` : 403 Forbidden により失敗

------
https://chatgpt.com/codex/tasks/task_e_689e04cfec4c832ab60902efd5eef84d