### PR TITLE
RendererとColliderの型チェックを追加

### DIFF
--- a/UISpriteOverlapDetector/source/UISpriteOverlapDetector.cs
+++ b/UISpriteOverlapDetector/source/UISpriteOverlapDetector.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
-/// UI(RectTransform)と非UI(SpriteRenderer/Collider2D)のスクリーン上での重なりを検出するクラス
+/// UI(RectTransform)と非UI(Renderer/Collider)のスクリーン上での重なりを検出するクラス
 /// </summary>
 [DisallowMultipleComponent]
 public sealed class UISpriteOverlapDetector : MonoBehaviour
@@ -67,14 +67,15 @@ public sealed class UISpriteOverlapDetector : MonoBehaviour
             Debug.LogWarning("RectTransformは非UIリストに追加できません", this);
             return;
         }
-        if (comp is not SpriteRenderer &&
-            comp is not LineRenderer &&
-            comp is not MeshRenderer &&
-            comp is not Collider &&
-            comp is not Collider2D)
+        switch (comp)
         {
-            Debug.LogWarning($"{comp.GetType().Name}は非UIリストに追加できません", this);
-            return;
+            case Renderer:
+            case Collider:
+            case Collider2D:
+                break;
+            default:
+                Debug.LogWarning($"{comp.GetType().Name}は非UIリストに追加できません", this);
+                return;
         }
         if (notUIs.Contains(comp)) return;
 
@@ -106,12 +107,16 @@ public sealed class UISpriteOverlapDetector : MonoBehaviour
         }
         for (int i = notUIs.Count - 1; i >= 0; i--)
         {
-            if (notUIs[i] is not SpriteRenderer && 
-                notUIs[i] is not LineRenderer &&
-                notUIs[i] is not Collider2D)
+            switch (notUIs[i])
             {
-                Debug.LogWarning($"非UIリストに対応外コンポーネントが含まれています: {notUIs[i].name}", this);
-                notUIs.RemoveAt(i);
+                case Renderer:
+                case Collider:
+                case Collider2D:
+                    break;
+                default:
+                    Debug.LogWarning($"非UIリストに対応外コンポーネントが含まれています: {notUIs[i].name}", this);
+                    notUIs.RemoveAt(i);
+                    break;
             }
         }
 


### PR DESCRIPTION
## 概要
- 非UIリストの登録時にRendererとColliderの型チェックを追加
- Awake内でもRenderer/Colliderを判定するよう条件分岐を整理

## テスト
- `dotnet build UISpriteOverlapDetector.sln` : command not found
- `apt-get update` : 403エラーのため失敗


------
https://chatgpt.com/codex/tasks/task_e_689e0bf8a39c832a894e0d1654a2c518