### PR TITLE
奥行き判定を追加して重なり検出を改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - 非 UI コンポーネントの境界取得は `IBoundsProvider` で拡張可能
   - 標準で `SpriteRenderer`、`LineRenderer`、`MeshRenderer`、`Collider` 用を内蔵
 - `IncludeRotated` オプションで自動的に判定方法を切り替え
+- 奥行きを考慮するかを `useDepthCheck` で切り替え可能
 - Gizmos による確認用のデバッグ描画
 
 ## クラス図
@@ -32,7 +33,7 @@ classDiagram
     
     class IOverlapStrategy {
         <<interface>>
-        + bool Overlap(IReadOnlyList<Vector2> a, IReadOnlyList<Vector2> b)
+        + bool Overlap(IReadOnlyList<Vector3> a, IReadOnlyList<Vector3> b)
     }
 
     class AABBStrategy
@@ -68,6 +69,7 @@ classDiagram
         - HashSet previousState
         - IOverlapStrategy strategy
         + bool IncludeRotated
+        + bool useDepthCheck
 
         + event OnOverlapEnter
         + event OnOverlapStay

--- a/UISpriteOverlapDetector/source/AABBStrategy.cs
+++ b/UISpriteOverlapDetector/source/AABBStrategy.cs
@@ -3,14 +3,14 @@ using UnityEngine;
 
 public sealed class AABBStrategy : IOverlapStrategy
 {
-    public bool Overlap(IReadOnlyList<Vector2> a, IReadOnlyList<Vector2> b)
+    public bool Overlap(IReadOnlyList<Vector3> a, IReadOnlyList<Vector3> b)
     {
         Rect ra = CalcBoundingRect(a);
         Rect rb = CalcBoundingRect(b);
         return ra.Overlaps(rb);
     }
 
-    private static Rect CalcBoundingRect(IReadOnlyList<Vector2> points)
+    private static Rect CalcBoundingRect(IReadOnlyList<Vector3> points)
     {
         float minX = points[0].x, minY = points[0].y;
         float maxX = points[0].x, maxY = points[0].y;

--- a/UISpriteOverlapDetector/source/IOverlapStrategy.cs
+++ b/UISpriteOverlapDetector/source/IOverlapStrategy.cs
@@ -4,5 +4,5 @@ using UnityEngine;
 public interface IOverlapStrategy
 {
     // OBB や Rect 型ではなく、任意数の頂点リストを受け取る
-    bool Overlap(IReadOnlyList<Vector2> a, IReadOnlyList<Vector2> b);
+    bool Overlap(IReadOnlyList<Vector3> a, IReadOnlyList<Vector3> b);
 }

--- a/UISpriteOverlapDetector/source/SATStrategy.cs
+++ b/UISpriteOverlapDetector/source/SATStrategy.cs
@@ -3,13 +3,15 @@ using UnityEngine;
 
 public sealed class SATStrategy : IOverlapStrategy
 {
-    public bool Overlap(IReadOnlyList<Vector2> a, IReadOnlyList<Vector2> b)
+    public bool Overlap(IReadOnlyList<Vector3> a, IReadOnlyList<Vector3> b)
     {
         // 分離軸定理による重なり判定
         for (int i = 0; i < a.Count; ++i)
         {
-            Vector2 edge = a[(i + 1) % a.Count] - a[i];
-            Vector2 axis = new Vector2(-edge.y, edge.x).normalized;
+            Vector2 ai = new(a[i].x, a[i].y);
+            Vector2 anext = new(a[(i + 1) % a.Count].x, a[(i + 1) % a.Count].y);
+            Vector2 edge = anext - ai;
+            Vector2 axis = new(-edge.y, edge.x).normalized;
             if (IsOverlapOnAxis(a, b, axis) == false)
             {
                 return false;
@@ -17,8 +19,10 @@ public sealed class SATStrategy : IOverlapStrategy
         }
         for (int i = 0; i < b.Count; ++i)
         {
-            Vector2 edge = b[(i + 1) % b.Count] - b[i];
-            Vector2 axis = new Vector2(-edge.y, edge.x).normalized;
+            Vector2 bi = new(b[i].x, b[i].y);
+            Vector2 bnext = new(b[(i + 1) % b.Count].x, b[(i + 1) % b.Count].y);
+            Vector2 edge = bnext - bi;
+            Vector2 axis = new(-edge.y, edge.x).normalized;
             if (IsOverlapOnAxis(a, b, axis) == false)
             {
                 return false;
@@ -27,20 +31,22 @@ public sealed class SATStrategy : IOverlapStrategy
         return true;
     }
 
-    private static bool IsOverlapOnAxis(IReadOnlyList<Vector2> A, IReadOnlyList<Vector2> B, Vector2 axis)
+    private static bool IsOverlapOnAxis(IReadOnlyList<Vector3> A, IReadOnlyList<Vector3> B, Vector2 axis)
     {
         Project(A, axis, out float minA, out float maxA);
         Project(B, axis, out float minB, out float maxB);
         return maxA >= minB && maxB >= minA;
     }
 
-    private static void Project(IReadOnlyList<Vector2> pts, Vector2 axis, out float min, out float max)
+    private static void Project(IReadOnlyList<Vector3> pts, Vector2 axis, out float min, out float max)
     {
-        min = Vector2.Dot(pts[0], axis);
-        max = Vector2.Dot(pts[0], axis);
+        Vector2 p0 = new(pts[0].x, pts[0].y);
+        min = Vector2.Dot(p0, axis);
+        max = min;
         for (int i = 1; i < pts.Count; ++i)
         {
-            float d = Vector2.Dot(pts[i], axis);
+            Vector2 p = new(pts[i].x, pts[i].y);
+            float d = Vector2.Dot(p, axis);
             if (d < min)      min = d;
             else if (d > max) max = d;
         }


### PR DESCRIPTION
## 概要
- スクリーン投影時にZ値を保持し奥行きを取得
- 非UIが手前にある場合のみ重なりを検出
- 奥行き判定のオン/オフを切り替えるオプションを追加

## テスト
- `dotnet build` (コマンドが見つからず失敗)
- `apt-get update` (リポジトリ署名エラーのため失敗)


------
https://chatgpt.com/codex/tasks/task_e_689e0e93a59c832a8e878999ccb2e9fc